### PR TITLE
feat: tiered LinkedIn apply resolver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Secrets & auth state — NEVER commit these
+.env
+.env.local
+*_storage_state.json
+linkedin_storage_state.json
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+
+# Editor
+.vscode/
+.idea/

--- a/README.md
+++ b/README.md
@@ -74,6 +74,52 @@ Uses Gmail API to read Google Alert emails:
 
 Requires Gmail API server running on `localhost:3001`.
 
+## LinkedIn Authentication Bootstrap
+
+The resolver uses LinkedIn session cookies (`li_at` + `JSESSIONID`) for the
+Voyager API tier.  A helper script captures them via a headed browser login.
+
+### 1. Capture credentials (one-time)
+
+```bash
+# Print cookies to stdout only
+python scripts/capture_linkedin_auth.py
+
+# Save cookies to .env.local AND storage-state JSON
+python scripts/capture_linkedin_auth.py --save-env --save-storage-state
+```
+
+A headed Chromium window opens → log in to LinkedIn → return to terminal and
+press ENTER.  The script writes:
+
+| Flag | Output |
+|------|--------|
+| *(none)* | Prints `LI_AT` / `JSESSIONID` to stdout |
+| `--save-env` | Upserts values into `.env.local` |
+| `--save-storage-state [PATH]` | Saves Playwright storage-state JSON (default `linkedin_storage_state.json`) |
+
+### 2. Use with the resolver
+
+```bash
+# Auto-loaded from .env.local (no flags needed)
+python resolve_apply_paths.py --input output/all_jobs.json
+
+# Or pass explicitly
+python resolve_apply_paths.py \
+  --linkedin-li-at "$LI_AT" \
+  --linkedin-jsessionid "$JSESSIONID"
+
+# Or use Playwright storage state
+python resolve_apply_paths.py --storage-state linkedin_storage_state.json
+```
+
+### ⚠️ Security notes
+
+* **Never commit** `.env.local`, `.env`, or `*_storage_state.json` — they
+  contain session secrets.  These are already in `.gitignore`.
+* Cookies expire when LinkedIn invalidates the session (typically 1-3 months).
+  Re-run the capture script when requests start returning `401`/`403`.
+
 ## Next Steps
 
 1. **Fix We Work Remotely** - Site changed selectors

--- a/resolve_apply_paths.py
+++ b/resolve_apply_paths.py
@@ -24,6 +24,14 @@ from typing import Any, Dict, Optional
 from urllib.parse import urlparse
 
 import requests
+from dotenv import load_dotenv
+
+# Auto-load .env.local (takes precedence) then .env for LI_AT / JSESSIONID
+_repo_root = Path(__file__).resolve().parent
+for _env_file in (".env.local", ".env"):
+    _env_path = _repo_root / _env_file
+    if _env_path.exists():
+        load_dotenv(_env_path, override=False)
 
 try:
     from playwright.sync_api import sync_playwright

--- a/scripts/capture_linkedin_auth.py
+++ b/scripts/capture_linkedin_auth.py
@@ -1,0 +1,115 @@
+"""
+Capture LinkedIn authentication for the job resolver.
+
+Opens a headed Chromium browser, lets the user log in manually,
+then extracts li_at + JSESSIONID cookies and (optionally) saves
+Playwright storage-state JSON and/or a .env.local file.
+
+Usage:
+  python scripts/capture_linkedin_auth.py
+  python scripts/capture_linkedin_auth.py --save-env
+  python scripts/capture_linkedin_auth.py --save-env --save-storage-state auth_state.json
+
+⚠️  NEVER commit .env.local or storage-state JSON — they contain session secrets.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def _extract_cookies(cookies: list[dict], names: set[str]) -> dict[str, str]:
+    """Return {name: value} for cookies whose name is in *names*."""
+    return {c["name"]: c["value"] for c in cookies if c["name"] in names}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Capture LinkedIn session cookies via headed browser login.",
+    )
+    ap.add_argument(
+        "--save-env",
+        action="store_true",
+        help="Write LI_AT and JSESSIONID to .env.local in the repo root.",
+    )
+    ap.add_argument(
+        "--save-storage-state",
+        metavar="PATH",
+        nargs="?",
+        const="linkedin_storage_state.json",
+        default=None,
+        help="Save full Playwright storage state JSON (default: linkedin_storage_state.json).",
+    )
+    args = ap.parse_args()
+
+    try:
+        from playwright.sync_api import sync_playwright
+    except Exception:
+        print("❌ Playwright is not available. Install dependencies and run: playwright install chromium")
+        return 1
+
+    print("🔐 Opening LinkedIn login page in headed Chromium…")
+    print("   Log in manually, then return here and press ENTER when done.\n")
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=False)
+        context = browser.new_context()
+        page = context.new_page()
+        page.goto("https://www.linkedin.com/login", wait_until="domcontentloaded")
+
+        input("✅ Press ENTER after you have logged in successfully → ")
+
+        # --- extract cookies ---
+        cookies = context.cookies("https://www.linkedin.com")
+        wanted = _extract_cookies(cookies, {"li_at", "JSESSIONID"})
+
+        li_at = wanted.get("li_at", "")
+        jsessionid = wanted.get("JSESSIONID", "")
+
+        if not li_at:
+            print("❌ li_at cookie not found — login may have failed.")
+            browser.close()
+            return 1
+
+        # --- display to stdout ---
+        print("\n─── Extracted credentials ───")
+        print(f"LI_AT={li_at}")
+        print(f"JSESSIONID={jsessionid}")
+        print("─────────────────────────────\n")
+
+        # --- optional: save .env.local ---
+        if args.save_env:
+            env_path = Path(__file__).resolve().parent.parent / ".env.local"
+            lines: list[str] = []
+            if env_path.exists():
+                lines = env_path.read_text().splitlines()
+            # upsert keys
+            key_map = {"LI_AT": li_at, "JSESSIONID": jsessionid}
+            for key, val in key_map.items():
+                found = False
+                for i, line in enumerate(lines):
+                    if line.startswith(f"{key}="):
+                        lines[i] = f"{key}={val}"
+                        found = True
+                        break
+                if not found:
+                    lines.append(f"{key}={val}")
+            env_path.write_text("\n".join(lines) + "\n")
+            print(f"📄 Saved to {env_path}")
+
+        # --- optional: save storage state ---
+        if args.save_storage_state is not None:
+            ss_path = Path(__file__).resolve().parent.parent / args.save_storage_state
+            context.storage_state(path=str(ss_path))
+            print(f"📦 Storage state saved to {ss_path}")
+
+        context.close()
+        browser.close()
+
+    print("\n⚠️  These credentials are secrets — do NOT commit them to git.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary\nImplements a tiered resolver strategy for LinkedIn apply-path classification in esolve_apply_paths.py:\n1. Voyager API (auth cookie based)\n2. Authenticated Playwright (storage state based)\n3. Enhanced guest parser\n4. Passthrough fallback\n\n## What changed\n- Added ResolverConfig dataclass and tiered orchestration in esolve_job_apply.\n- Added Voyager resolver (esolve_via_voyager) with LI_AT + JSESSIONID support.\n- Added authenticated Playwright resolver (esolve_via_authenticated_playwright) with optional --storage-state and --headful.\n- Upgraded guest resolver heuristics and outbound-link extraction.\n- Added CLI options: --linkedin-li-at, --linkedin-jsessionid, --storage-state, --headful, --delay-ms, --timeout-s.\n- Added esolver_summary counts to output JSON.\n\n## Validation\n- Ran: python resolve_apply_paths.py --limit 3 --delay-ms 10\n- Result: completed successfully with resolver breakdown output.\n\nCloses #13