### PR TITLE
feat: add hiring intent signal source module (#17)

### DIFF
--- a/pipeline/hiring_intent_signals.py
+++ b/pipeline/hiring_intent_signals.py
@@ -1,0 +1,168 @@
+"""Hiring intent signal normalization for startup job sources (Issue #17)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+from pydantic import BaseModel, Field
+
+SUPPORTED_SOURCES = {"wellfound", "naukri", "cutshort", "instahyre", "yc_jobs"}
+MAX_SIGNAL_AGE_DAYS = 60
+TRACKING_QUERY_KEYS = {
+    "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content",
+    "gclid", "fbclid", "msclkid", "mc_cid", "mc_eid",
+    "src", "source", "ref", "referrer", "referral", "feedid", "trackingid",
+    "li_fat_id", "trk", "trkemail", "gh_src",
+}
+
+
+def _normalize_text(value: str | None) -> str:
+    return " ".join((value or "").lower().split()).strip()
+
+
+def _canonicalize_url(raw_url: str | None) -> str:
+    if not raw_url:
+        return ""
+
+    parts = urlsplit(raw_url.strip())
+    scheme = parts.scheme.lower()
+    netloc = parts.netloc.lower()
+
+    path = parts.path or "/"
+    if path != "/":
+        path = path.rstrip("/")
+
+    kept = []
+    for key, value in parse_qsl(parts.query, keep_blank_values=True):
+        key_lower = key.lower()
+        if key_lower in TRACKING_QUERY_KEYS or key_lower.startswith("utm_"):
+            continue
+        kept.append((key, value))
+    kept.sort(key=lambda item: (item[0], item[1]))
+
+    query = urlencode(kept)
+    return urlunsplit((scheme, netloc, path, query, ""))
+
+
+class HiringIntentSignal(BaseModel):
+    """Normalized hiring intent record shared across source modules."""
+
+    source: str
+    company: str
+    role: str
+    location: str = ""
+    posted_date: str
+    source_url: str
+    canonical_url: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @property
+    def dedupe_key(self) -> str:
+        return "|".join(
+            [
+                _normalize_text(self.company),
+                _normalize_text(self.role),
+                self.canonical_url,
+            ]
+        )
+
+
+def _to_datetime(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.astimezone(UTC) if value.tzinfo else value.replace(tzinfo=UTC)
+
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+
+        for parser in (
+            lambda t: datetime.fromisoformat(t),
+            lambda t: datetime.strptime(t, "%Y-%m-%d"),
+            lambda t: datetime.strptime(t, "%d-%m-%Y"),
+            lambda t: datetime.strptime(t, "%d/%m/%Y"),
+            lambda t: datetime.strptime(t, "%b %d, %Y"),
+            lambda t: datetime.strptime(t, "%B %d, %Y"),
+        ):
+            try:
+                parsed = parser(text)
+                return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)
+            except ValueError:
+                continue
+
+    return None
+
+
+def _pick(record: dict[str, Any], candidates: list[str]) -> Any:
+    for key in candidates:
+        if key in record and record[key] not in (None, ""):
+            return record[key]
+    return None
+
+
+def _normalize_record(record: dict[str, Any], source: str, now: datetime) -> HiringIntentSignal | None:
+    company = _pick(record, ["company", "company_name", "startup", "org", "organization"])
+    role = _pick(record, ["role", "title", "job_title", "position"])
+    location = _pick(record, ["location", "job_location", "city", "region"]) or ""
+    source_url = _pick(record, ["source_url", "url", "job_url", "apply_url", "link"])
+    posted_raw = _pick(record, ["posted_date", "posted_at", "created_at", "published_at", "date"])
+
+    if not all([company, role, source_url, posted_raw]):
+        return None
+
+    posted_dt = _to_datetime(posted_raw)
+    if posted_dt is None:
+        return None
+
+    if posted_dt < (now - timedelta(days=MAX_SIGNAL_AGE_DAYS)):
+        return None
+
+    canonical_url = _canonicalize_url(str(source_url))
+
+    return HiringIntentSignal(
+        source=source,
+        company=str(company).strip(),
+        role=str(role).strip(),
+        location=str(location).strip(),
+        posted_date=posted_dt.date().isoformat(),
+        source_url=str(source_url).strip(),
+        canonical_url=canonical_url,
+        metadata={k: v for k, v in record.items() if k not in {"company", "company_name", "startup", "org", "organization", "role", "title", "job_title", "position", "location", "job_location", "city", "region", "source_url", "url", "job_url", "apply_url", "link", "posted_date", "posted_at", "created_at", "published_at", "date"}},
+    )
+
+
+def build_hiring_intent_signals(source_records: dict[str, list[dict[str, Any]]], now: datetime | None = None) -> list[dict[str, Any]]:
+    """Normalize, freshness-filter, and dedupe startup hiring intent records.
+
+    Args:
+        source_records: Map of source name -> list of raw source records.
+        now: Optional fixed timestamp for deterministic tests.
+
+    Returns:
+        List of normalized signal dictionaries.
+    """
+
+    now_dt = now.astimezone(UTC) if now else datetime.now(tz=UTC)
+
+    deduped: dict[str, HiringIntentSignal] = {}
+    for source, records in source_records.items():
+        source_name = source.lower().strip()
+        if source_name not in SUPPORTED_SOURCES:
+            continue
+
+        for record in records:
+            signal = _normalize_record(record, source=source_name, now=now_dt)
+            if signal is None:
+                continue
+
+            if signal.dedupe_key not in deduped:
+                deduped[signal.dedupe_key] = signal
+
+    return [signal.model_dump() for signal in deduped.values()]

--- a/tests/fixtures/hiring_intent_signals/cutshort.json
+++ b/tests/fixtures/hiring_intent_signals/cutshort.json
@@ -1,0 +1,9 @@
+[
+  {
+    "startup": "CutCo",
+    "role": "Onboarding Specialist",
+    "city": "Delhi",
+    "link": "https://cutshort.io/job/onboarding-specialist-1?ref=feed",
+    "created_at": "2026-02-28T10:00:00Z"
+  }
+]

--- a/tests/fixtures/hiring_intent_signals/instahyre.json
+++ b/tests/fixtures/hiring_intent_signals/instahyre.json
@@ -1,0 +1,9 @@
+[
+  {
+    "organization": "Insta Startup",
+    "position": "Customer Support Lead",
+    "region": "Mumbai",
+    "apply_url": "https://www.instahyre.com/job-501?fbclid=abc",
+    "published_at": "Mar 10, 2026"
+  }
+]

--- a/tests/fixtures/hiring_intent_signals/naukri.json
+++ b/tests/fixtures/hiring_intent_signals/naukri.json
@@ -1,0 +1,16 @@
+[
+  {
+    "company": "Acme Labs",
+    "job_title": "Customer Success Manager",
+    "job_location": "Remote India",
+    "job_url": "https://wellfound.com/jobs/123/?utm_medium=email",
+    "date": "2026-03-03"
+  },
+  {
+    "company": "Naukri Startup",
+    "job_title": "Implementation Consultant",
+    "job_location": "Pune",
+    "job_url": "https://www.naukri.com/job-listings-implementation-consultant-abc-1001?src=jobsearchDesk",
+    "date": "2026-02-15"
+  }
+]

--- a/tests/fixtures/hiring_intent_signals/wellfound.json
+++ b/tests/fixtures/hiring_intent_signals/wellfound.json
@@ -1,0 +1,16 @@
+[
+  {
+    "company_name": "Acme Labs",
+    "title": "Customer Success Manager",
+    "location": "Remote India",
+    "url": "https://wellfound.com/jobs/123?utm_source=newsletter",
+    "posted_at": "2026-03-01"
+  },
+  {
+    "company_name": "OldCo",
+    "title": "Support Specialist",
+    "location": "Bangalore",
+    "url": "https://wellfound.com/jobs/999",
+    "posted_at": "2025-12-01"
+  }
+]

--- a/tests/fixtures/hiring_intent_signals/yc_jobs.json
+++ b/tests/fixtures/hiring_intent_signals/yc_jobs.json
@@ -1,0 +1,16 @@
+[
+  {
+    "org": "YC Rocket",
+    "title": "Customer Success Associate",
+    "location": "Remote",
+    "source_url": "https://www.workatastartup.com/jobs/42?utm_campaign=weekly",
+    "posted_date": "2026-03-12"
+  },
+  {
+    "org": "Broken Startup",
+    "title": "CS Ops",
+    "location": "Remote",
+    "source_url": "",
+    "posted_date": "2026-03-12"
+  }
+]

--- a/tests/test_hiring_intent_signals.py
+++ b/tests/test_hiring_intent_signals.py
@@ -1,0 +1,81 @@
+import json
+import unittest
+from datetime import UTC, datetime
+from pathlib import Path
+
+from pipeline.hiring_intent_signals import build_hiring_intent_signals
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "hiring_intent_signals"
+
+
+class TestHiringIntentSignals(unittest.TestCase):
+    def _load(self, name: str):
+        return json.loads((FIXTURE_DIR / f"{name}.json").read_text(encoding="utf-8"))
+
+    def test_normalized_schema_freshness_and_dedupe(self):
+        source_records = {
+            "wellfound": self._load("wellfound"),
+            "naukri": self._load("naukri"),
+            "cutshort": self._load("cutshort"),
+            "instahyre": self._load("instahyre"),
+            "yc_jobs": self._load("yc_jobs"),
+        }
+
+        signals = build_hiring_intent_signals(
+            source_records,
+            now=datetime(2026, 3, 20, tzinfo=UTC),
+        )
+
+        # 8 raw rows -> remove 1 stale + 1 invalid + 1 duplicate = 5 unique fresh signals.
+        self.assertEqual(len(signals), 5)
+
+        required_fields = {
+            "source",
+            "company",
+            "role",
+            "location",
+            "posted_date",
+            "source_url",
+            "canonical_url",
+            "metadata",
+        }
+        for signal in signals:
+            self.assertEqual(set(signal.keys()), required_fields)
+
+            posted = datetime.fromisoformat(signal["posted_date"]).replace(tzinfo=UTC)
+            age_days = (datetime(2026, 3, 20, tzinfo=UTC) - posted).days
+            self.assertLessEqual(age_days, 60)
+
+        dedupe_keys = {
+            (s["company"].lower().strip(), s["role"].lower().strip(), s["canonical_url"]) for s in signals
+        }
+        self.assertEqual(len(dedupe_keys), len(signals))
+
+        # Canonical URL normalization strips tracking params and normalizes trailing slash.
+        acme_urls = [
+            s["canonical_url"]
+            for s in signals
+            if s["company"] == "Acme Labs" and s["role"] == "Customer Success Manager"
+        ]
+        self.assertEqual(acme_urls, ["https://wellfound.com/jobs/123"])
+
+    def test_ignores_unknown_source(self):
+        signals = build_hiring_intent_signals(
+            {
+                "unknown_source": [
+                    {
+                        "company": "X",
+                        "title": "Y",
+                        "url": "https://example.com/job",
+                        "posted_date": "2026-03-19",
+                    }
+                ]
+            },
+            now=datetime(2026, 3, 20, tzinfo=UTC),
+        )
+
+        self.assertEqual(signals, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements #17 (part of #16).

## What's included
- Added `pipeline/hiring_intent_signals.py` to normalize hiring-intent rows from Wellfound, Naukri, Cutshort, Instahyre, and YC Jobs.
- Normalized output schema: `company`, `role`, `location`, `posted_date`, `source_url` (+ `canonical_url`, `source`, `metadata`).
- Enforced freshness filter for postings older than 60 days.
- Added deterministic dedupe by `company + role + canonical_url`.
- Added fixture-backed unit tests covering normalization, freshness pruning, URL canonicalization, dedupe behavior, and unsupported source handling.

## Test
- `python -m pytest -q tests/test_hiring_intent_signals.py`