### PR TITLE
Issue #22: deterministic founder/business email enrichment waterfall

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,29 @@ Jobs saved to `output/`:
 - `business_development.json` - BD roles only
 - `last_run.json` - Run statistics
 
+### Contact Enrichment Waterfall (Issue #22)
+
+Each job now supports deterministic founder/business email enrichment:
+
+1. Hunter lookup
+2. Apollo lookup
+3. Pattern guess fallback (`first@domain`, then variants, then `info@domain`)
+
+It records provenance per attempt (`contact_provenance`) and a confidence score (`contact_confidence`) by source:
+
+- Hunter: `0.95`
+- Apollo: `0.88`
+- Pattern guess: `0.55`
+
+Retry/backoff is built-in for transient and rate-limit failures.
+
+Set API keys to enable provider calls:
+
+```bash
+export HUNTER_API_KEY=...
+export APOLLO_API_KEY=...
+```
+
 ## Job Schema
 
 ```json
@@ -61,7 +84,13 @@ Jobs saved to `output/`:
   "job_type": "customer_success",
   "source": "remote_ok",
   "source_url": "https://remoteok.com/...",
-  "apply_url": "https://remoteok.com/..."
+  "apply_url": "https://remoteok.com/...",
+  "founder_email": "jane@techcorp.com",
+  "business_email": "jane@techcorp.com",
+  "contact_email": "jane@techcorp.com",
+  "contact_email_source": "hunter",
+  "contact_confidence": 0.95,
+  "contact_provenance": [{"source": "hunter", "attempt": 1, "status": "success"}]
 }
 ```
 

--- a/job_scraper.py
+++ b/job_scraper.py
@@ -16,7 +16,9 @@ import aiohttp
 import requests
 from bs4 import BeautifulSoup
 import hashlib
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+from pipeline.contact_enrichment import ApolloProvider, ContactEnricher, HunterProvider, RetryPolicy
 
 # Config
 CONFIG_PATH = Path(__file__).parent / "config.json"
@@ -37,6 +39,12 @@ class Job(BaseModel):
     scraped_at: str
     salary: str | None = None
     apply_url: str | None = None
+    founder_email: str | None = None
+    business_email: str | None = None
+    contact_email: str | None = None
+    contact_email_source: str | None = None
+    contact_confidence: float = 0.0
+    contact_provenance: list[dict[str, Any]] = Field(default_factory=list)
 
 class JobScraper:
     """Main job scraper with source adapters."""
@@ -48,7 +56,36 @@ class JobScraper:
         self.output_dir = OUTPUT_DIR
         self.output_dir.mkdir(exist_ok=True)
         self.headers = {"User-Agent": "Mozilla/5.0"}
+        self._contact_enricher = self._build_contact_enricher()
     
+    def _build_contact_enricher(self) -> ContactEnricher | None:
+        hunter_key = os.getenv("HUNTER_API_KEY", "").strip()
+        apollo_key = os.getenv("APOLLO_API_KEY", "").strip()
+        if not (hunter_key and apollo_key):
+            return None
+        return ContactEnricher(
+            hunter_provider=HunterProvider(hunter_key),
+            apollo_provider=ApolloProvider(apollo_key),
+            retry_policy=RetryPolicy(max_attempts=3, initial_backoff_seconds=0.5, max_backoff_seconds=3.0),
+        )
+
+    def _enrich_contact(self, *, company: str, source_url: str, founder_name: str | None = None) -> dict[str, Any]:
+        if not self._contact_enricher:
+            return {}
+
+        domain = self._extract_domain(source_url)
+        if not domain:
+            return {}
+
+        result = self._contact_enricher.enrich(founder_name=founder_name, domain=domain, company=company)
+        return result.to_dict()
+
+    def _extract_domain(self, url: str) -> str:
+        match = re.search(r"^https?://([^/]+)", (url or "").strip().lower())
+        if not match:
+            return ""
+        return match.group(1).removeprefix("www.")
+
     def generate_job_id(self, title: str, company: str, source_url: str) -> str:
         raw = f"{title}-{company}-{source_url}".lower().strip()
         return hashlib.md5(raw.encode()).hexdigest()[:12]
@@ -60,6 +97,8 @@ class JobScraper:
         remote = any(x in location.lower() for x in ['remote', 'work from home', 'wfh', 'india']) or \
                  location == "" or "global" in location.lower()
         
+        enriched = self._enrich_contact(company=company or "Unknown", source_url=source_url)
+
         return Job(
             id=self.generate_job_id(title, company, source_url),
             title=title,
@@ -73,7 +112,8 @@ class JobScraper:
             posted_date=posted_date or datetime.now().isoformat(),
             scraped_at=datetime.now().isoformat(),
             salary=salary,
-            apply_url=source_url
+            apply_url=source_url,
+            **enriched,
         )
     
     def classify_job_type(self, title: str, tags: List[str] = None, description: str = "") -> str:

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -1,0 +1,1 @@
+"""Pipeline modules."""

--- a/pipeline/contact_enrichment.py
+++ b/pipeline/contact_enrichment.py
@@ -1,0 +1,333 @@
+"""Deterministic founder/business email enrichment waterfall.
+
+Issue #22 scope:
+- Ordered waterfall: Hunter -> Apollo -> deterministic pattern guess
+- Provenance tracking for every stage/attempt
+- Contact confidence scoring with transparent source weighting
+- Retry/backoff for transient failures and provider rate-limits
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+import requests
+
+
+SOURCE_HUNTER = "hunter"
+SOURCE_APOLLO = "apollo"
+SOURCE_PATTERN_GUESS = "pattern_guess"
+
+
+class ProviderError(Exception):
+    """Base class for provider exceptions."""
+
+
+class TransientProviderError(ProviderError):
+    """Retryable provider error (network, upstream 5xx, timeout)."""
+
+
+class RateLimitError(ProviderError):
+    """Provider asked us to back off for retry_after_seconds."""
+
+    def __init__(self, retry_after_seconds: float = 1.0, message: str = "rate-limited") -> None:
+        self.retry_after_seconds = float(max(retry_after_seconds, 0.0))
+        super().__init__(message)
+
+
+class EmailProvider(Protocol):
+    """External provider contract used by the waterfall orchestrator."""
+
+    name: str
+
+    def lookup_email(self, *, founder_name: str | None, domain: str, company: str | None = None) -> str | None:
+        """Return discovered email or None when not found."""
+        ...
+
+
+class HunterProvider:
+    name = SOURCE_HUNTER
+
+    def __init__(self, api_key: str, *, session: requests.Session | None = None) -> None:
+        self._api_key = api_key
+        self._session = session or requests.Session()
+
+    def lookup_email(self, *, founder_name: str | None, domain: str, company: str | None = None) -> str | None:
+        params: dict[str, str] = {"domain": domain, "api_key": self._api_key}
+        first, last = _split_name(founder_name)
+        if first:
+            params["first_name"] = first
+        if last:
+            params["last_name"] = last
+
+        response = self._session.get("https://api.hunter.io/v2/email-finder", params=params, timeout=12)
+        if response.status_code == 429:
+            raise RateLimitError(_retry_after(response), "hunter rate-limited")
+        if response.status_code >= 500:
+            raise TransientProviderError(f"hunter upstream {response.status_code}")
+        if response.status_code >= 400:
+            raise ProviderError(f"hunter http {response.status_code}")
+
+        data = response.json().get("data", {})
+        return data.get("email")
+
+
+class ApolloProvider:
+    name = SOURCE_APOLLO
+
+    def __init__(self, api_key: str, *, session: requests.Session | None = None) -> None:
+        self._api_key = api_key
+        self._session = session or requests.Session()
+
+    def lookup_email(self, *, founder_name: str | None, domain: str, company: str | None = None) -> str | None:
+        payload: dict[str, str] = {"domain": domain}
+        if founder_name:
+            payload["name"] = founder_name
+        if company:
+            payload["organization_name"] = company
+
+        response = self._session.post(
+            "https://api.apollo.io/api/v1/people/match",
+            json=payload,
+            headers={"x-api-key": self._api_key},
+            timeout=12,
+        )
+        if response.status_code == 429:
+            raise RateLimitError(_retry_after(response), "apollo rate-limited")
+        if response.status_code >= 500:
+            raise TransientProviderError(f"apollo upstream {response.status_code}")
+        if response.status_code >= 400:
+            raise ProviderError(f"apollo http {response.status_code}")
+
+        person = response.json().get("person") or {}
+        return person.get("email")
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    max_attempts: int = 3
+    initial_backoff_seconds: float = 0.25
+    max_backoff_seconds: float = 2.0
+    backoff_multiplier: float = 2.0
+
+
+@dataclass
+class ContactEnrichmentResult:
+    founder_email: str | None = None
+    business_email: str | None = None
+    contact_email: str | None = None
+    contact_email_source: str | None = None
+    contact_confidence: float = 0.0
+    contact_provenance: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "founder_email": self.founder_email,
+            "business_email": self.business_email,
+            "contact_email": self.contact_email,
+            "contact_email_source": self.contact_email_source,
+            "contact_confidence": float(round(self.contact_confidence, 4)),
+            "contact_provenance": self.contact_provenance,
+        }
+
+
+CONFIDENCE_BY_SOURCE = {
+    SOURCE_HUNTER: 0.95,
+    SOURCE_APOLLO: 0.88,
+    SOURCE_PATTERN_GUESS: 0.55,
+}
+
+
+class ContactEnricher:
+    """Deterministic waterfall orchestrator for founder/business email enrichment."""
+
+    def __init__(
+        self,
+        *,
+        hunter_provider: EmailProvider,
+        apollo_provider: EmailProvider,
+        retry_policy: RetryPolicy | None = None,
+        sleep_fn=time.sleep,
+    ) -> None:
+        self._hunter = hunter_provider
+        self._apollo = apollo_provider
+        self._retry_policy = retry_policy or RetryPolicy()
+        self._sleep_fn = sleep_fn
+
+    def enrich(self, *, founder_name: str | None, domain: str, company: str | None = None) -> ContactEnrichmentResult:
+        normalized_domain = _normalize_domain(domain)
+        provenance: list[dict[str, Any]] = []
+
+        email = self._lookup_with_retry(
+            provider=self._hunter,
+            source=SOURCE_HUNTER,
+            founder_name=founder_name,
+            domain=normalized_domain,
+            company=company,
+            provenance=provenance,
+        )
+        if email:
+            return _build_result(email=email, source=SOURCE_HUNTER, provenance=provenance)
+
+        email = self._lookup_with_retry(
+            provider=self._apollo,
+            source=SOURCE_APOLLO,
+            founder_name=founder_name,
+            domain=normalized_domain,
+            company=company,
+            provenance=provenance,
+        )
+        if email:
+            return _build_result(email=email, source=SOURCE_APOLLO, provenance=provenance)
+
+        email = _pattern_guess(founder_name=founder_name, domain=normalized_domain)
+        provenance.append(
+            {
+                "source": SOURCE_PATTERN_GUESS,
+                "attempt": 1,
+                "status": "success" if email else "not_found",
+                "email": email,
+            }
+        )
+
+        if email:
+            return _build_result(email=email, source=SOURCE_PATTERN_GUESS, provenance=provenance)
+
+        return ContactEnrichmentResult(contact_provenance=provenance)
+
+    def _lookup_with_retry(
+        self,
+        *,
+        provider: EmailProvider,
+        source: str,
+        founder_name: str | None,
+        domain: str,
+        company: str | None,
+        provenance: list[dict[str, Any]],
+    ) -> str | None:
+        attempts = max(self._retry_policy.max_attempts, 1)
+        backoff = max(self._retry_policy.initial_backoff_seconds, 0.0)
+
+        for attempt in range(1, attempts + 1):
+            try:
+                email = provider.lookup_email(founder_name=founder_name, domain=domain, company=company)
+                provenance.append(
+                    {
+                        "source": source,
+                        "provider": provider.name,
+                        "attempt": attempt,
+                        "status": "success" if email else "not_found",
+                        "email": email,
+                    }
+                )
+                return _normalize_email(email)
+            except RateLimitError as exc:
+                provenance.append(
+                    {
+                        "source": source,
+                        "provider": provider.name,
+                        "attempt": attempt,
+                        "status": "rate_limited",
+                        "error": str(exc),
+                        "retry_after_seconds": exc.retry_after_seconds,
+                    }
+                )
+                if attempt >= attempts:
+                    break
+                self._sleep_fn(exc.retry_after_seconds)
+            except TransientProviderError as exc:
+                provenance.append(
+                    {
+                        "source": source,
+                        "provider": provider.name,
+                        "attempt": attempt,
+                        "status": "transient_error",
+                        "error": str(exc),
+                    }
+                )
+                if attempt >= attempts:
+                    break
+                self._sleep_fn(backoff)
+                backoff = min(backoff * self._retry_policy.backoff_multiplier, self._retry_policy.max_backoff_seconds)
+            except Exception as exc:  # deterministic fail-closed; no retries for unknown errors
+                provenance.append(
+                    {
+                        "source": source,
+                        "provider": provider.name,
+                        "attempt": attempt,
+                        "status": "fatal_error",
+                        "error": str(exc),
+                    }
+                )
+                break
+
+        return None
+
+
+def _build_result(*, email: str, source: str, provenance: list[dict[str, Any]]) -> ContactEnrichmentResult:
+    normalized_email = _normalize_email(email)
+    confidence = CONFIDENCE_BY_SOURCE[source]
+    founder_email = normalized_email if source != SOURCE_PATTERN_GUESS or "@" in normalized_email else None
+    return ContactEnrichmentResult(
+        founder_email=founder_email,
+        business_email=normalized_email,
+        contact_email=normalized_email,
+        contact_email_source=source,
+        contact_confidence=confidence,
+        contact_provenance=provenance,
+    )
+
+
+def _normalize_domain(domain: str) -> str:
+    cleaned = domain.strip().lower()
+    cleaned = re.sub(r"^https?://", "", cleaned)
+    cleaned = cleaned.split("/")[0]
+    return cleaned.removeprefix("www.")
+
+
+def _normalize_email(email: str | None) -> str | None:
+    if not email:
+        return None
+    return email.strip().lower()
+
+
+def _pattern_guess(*, founder_name: str | None, domain: str) -> str | None:
+    first, last = _split_name(founder_name)
+    if not first:
+        return f"info@{domain}" if domain else None
+
+    candidates: list[str] = [
+        f"{first}@{domain}",
+        f"{first}.{last}@{domain}" if last else "",
+        f"{first}{last}@{domain}" if last else "",
+        f"{first[0]}{last}@{domain}" if last else "",
+        f"{first}.{last[0]}@{domain}" if last else "",
+        f"info@{domain}",
+    ]
+
+    for candidate in candidates:
+        if candidate:
+            return candidate
+    return None
+
+
+def _split_name(name: str | None) -> tuple[str, str]:
+    if not name:
+        return "", ""
+    parts = [p.lower() for p in re.split(r"\s+", name.strip()) if p]
+    if not parts:
+        return "", ""
+    if len(parts) == 1:
+        return parts[0], ""
+    return parts[0], parts[-1]
+
+
+def _retry_after(response: requests.Response) -> float:
+    raw = response.headers.get("Retry-After", "1")
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return 1.0

--- a/pipeline/hiring_intent_signals.py
+++ b/pipeline/hiring_intent_signals.py
@@ -1,0 +1,168 @@
+"""Hiring intent signal normalization for startup job sources (Issue #17)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+from pydantic import BaseModel, Field
+
+SUPPORTED_SOURCES = {"wellfound", "naukri", "cutshort", "instahyre", "yc_jobs"}
+MAX_SIGNAL_AGE_DAYS = 60
+TRACKING_QUERY_KEYS = {
+    "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content",
+    "gclid", "fbclid", "msclkid", "mc_cid", "mc_eid",
+    "src", "source", "ref", "referrer", "referral", "feedid", "trackingid",
+    "li_fat_id", "trk", "trkemail", "gh_src",
+}
+
+
+def _normalize_text(value: str | None) -> str:
+    return " ".join((value or "").lower().split()).strip()
+
+
+def _canonicalize_url(raw_url: str | None) -> str:
+    if not raw_url:
+        return ""
+
+    parts = urlsplit(raw_url.strip())
+    scheme = parts.scheme.lower()
+    netloc = parts.netloc.lower()
+
+    path = parts.path or "/"
+    if path != "/":
+        path = path.rstrip("/")
+
+    kept = []
+    for key, value in parse_qsl(parts.query, keep_blank_values=True):
+        key_lower = key.lower()
+        if key_lower in TRACKING_QUERY_KEYS or key_lower.startswith("utm_"):
+            continue
+        kept.append((key, value))
+    kept.sort(key=lambda item: (item[0], item[1]))
+
+    query = urlencode(kept)
+    return urlunsplit((scheme, netloc, path, query, ""))
+
+
+class HiringIntentSignal(BaseModel):
+    """Normalized hiring intent record shared across source modules."""
+
+    source: str
+    company: str
+    role: str
+    location: str = ""
+    posted_date: str
+    source_url: str
+    canonical_url: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @property
+    def dedupe_key(self) -> str:
+        return "|".join(
+            [
+                _normalize_text(self.company),
+                _normalize_text(self.role),
+                self.canonical_url,
+            ]
+        )
+
+
+def _to_datetime(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.astimezone(UTC) if value.tzinfo else value.replace(tzinfo=UTC)
+
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+
+        for parser in (
+            lambda t: datetime.fromisoformat(t),
+            lambda t: datetime.strptime(t, "%Y-%m-%d"),
+            lambda t: datetime.strptime(t, "%d-%m-%Y"),
+            lambda t: datetime.strptime(t, "%d/%m/%Y"),
+            lambda t: datetime.strptime(t, "%b %d, %Y"),
+            lambda t: datetime.strptime(t, "%B %d, %Y"),
+        ):
+            try:
+                parsed = parser(text)
+                return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)
+            except ValueError:
+                continue
+
+    return None
+
+
+def _pick(record: dict[str, Any], candidates: list[str]) -> Any:
+    for key in candidates:
+        if key in record and record[key] not in (None, ""):
+            return record[key]
+    return None
+
+
+def _normalize_record(record: dict[str, Any], source: str, now: datetime) -> HiringIntentSignal | None:
+    company = _pick(record, ["company", "company_name", "startup", "org", "organization"])
+    role = _pick(record, ["role", "title", "job_title", "position"])
+    location = _pick(record, ["location", "job_location", "city", "region"]) or ""
+    source_url = _pick(record, ["source_url", "url", "job_url", "apply_url", "link"])
+    posted_raw = _pick(record, ["posted_date", "posted_at", "created_at", "published_at", "date"])
+
+    if not all([company, role, source_url, posted_raw]):
+        return None
+
+    posted_dt = _to_datetime(posted_raw)
+    if posted_dt is None:
+        return None
+
+    if posted_dt < (now - timedelta(days=MAX_SIGNAL_AGE_DAYS)):
+        return None
+
+    canonical_url = _canonicalize_url(str(source_url))
+
+    return HiringIntentSignal(
+        source=source,
+        company=str(company).strip(),
+        role=str(role).strip(),
+        location=str(location).strip(),
+        posted_date=posted_dt.date().isoformat(),
+        source_url=str(source_url).strip(),
+        canonical_url=canonical_url,
+        metadata={k: v for k, v in record.items() if k not in {"company", "company_name", "startup", "org", "organization", "role", "title", "job_title", "position", "location", "job_location", "city", "region", "source_url", "url", "job_url", "apply_url", "link", "posted_date", "posted_at", "created_at", "published_at", "date"}},
+    )
+
+
+def build_hiring_intent_signals(source_records: dict[str, list[dict[str, Any]]], now: datetime | None = None) -> list[dict[str, Any]]:
+    """Normalize, freshness-filter, and dedupe startup hiring intent records.
+
+    Args:
+        source_records: Map of source name -> list of raw source records.
+        now: Optional fixed timestamp for deterministic tests.
+
+    Returns:
+        List of normalized signal dictionaries.
+    """
+
+    now_dt = now.astimezone(UTC) if now else datetime.now(tz=UTC)
+
+    deduped: dict[str, HiringIntentSignal] = {}
+    for source, records in source_records.items():
+        source_name = source.lower().strip()
+        if source_name not in SUPPORTED_SOURCES:
+            continue
+
+        for record in records:
+            signal = _normalize_record(record, source=source_name, now=now_dt)
+            if signal is None:
+                continue
+
+            if signal.dedupe_key not in deduped:
+                deduped[signal.dedupe_key] = signal
+
+    return [signal.model_dump() for signal in deduped.values()]

--- a/tests/fixtures/hiring_intent_signals/cutshort.json
+++ b/tests/fixtures/hiring_intent_signals/cutshort.json
@@ -1,0 +1,9 @@
+[
+  {
+    "startup": "CutCo",
+    "role": "Onboarding Specialist",
+    "city": "Delhi",
+    "link": "https://cutshort.io/job/onboarding-specialist-1?ref=feed",
+    "created_at": "2026-02-28T10:00:00Z"
+  }
+]

--- a/tests/fixtures/hiring_intent_signals/instahyre.json
+++ b/tests/fixtures/hiring_intent_signals/instahyre.json
@@ -1,0 +1,9 @@
+[
+  {
+    "organization": "Insta Startup",
+    "position": "Customer Support Lead",
+    "region": "Mumbai",
+    "apply_url": "https://www.instahyre.com/job-501?fbclid=abc",
+    "published_at": "Mar 10, 2026"
+  }
+]

--- a/tests/fixtures/hiring_intent_signals/naukri.json
+++ b/tests/fixtures/hiring_intent_signals/naukri.json
@@ -1,0 +1,16 @@
+[
+  {
+    "company": "Acme Labs",
+    "job_title": "Customer Success Manager",
+    "job_location": "Remote India",
+    "job_url": "https://wellfound.com/jobs/123/?utm_medium=email",
+    "date": "2026-03-03"
+  },
+  {
+    "company": "Naukri Startup",
+    "job_title": "Implementation Consultant",
+    "job_location": "Pune",
+    "job_url": "https://www.naukri.com/job-listings-implementation-consultant-abc-1001?src=jobsearchDesk",
+    "date": "2026-02-15"
+  }
+]

--- a/tests/fixtures/hiring_intent_signals/wellfound.json
+++ b/tests/fixtures/hiring_intent_signals/wellfound.json
@@ -1,0 +1,16 @@
+[
+  {
+    "company_name": "Acme Labs",
+    "title": "Customer Success Manager",
+    "location": "Remote India",
+    "url": "https://wellfound.com/jobs/123?utm_source=newsletter",
+    "posted_at": "2026-03-01"
+  },
+  {
+    "company_name": "OldCo",
+    "title": "Support Specialist",
+    "location": "Bangalore",
+    "url": "https://wellfound.com/jobs/999",
+    "posted_at": "2025-12-01"
+  }
+]

--- a/tests/fixtures/hiring_intent_signals/yc_jobs.json
+++ b/tests/fixtures/hiring_intent_signals/yc_jobs.json
@@ -1,0 +1,16 @@
+[
+  {
+    "org": "YC Rocket",
+    "title": "Customer Success Associate",
+    "location": "Remote",
+    "source_url": "https://www.workatastartup.com/jobs/42?utm_campaign=weekly",
+    "posted_date": "2026-03-12"
+  },
+  {
+    "org": "Broken Startup",
+    "title": "CS Ops",
+    "location": "Remote",
+    "source_url": "",
+    "posted_date": "2026-03-12"
+  }
+]

--- a/tests/test_contact_enrichment.py
+++ b/tests/test_contact_enrichment.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from pipeline.contact_enrichment import (
+    ContactEnricher,
+    RateLimitError,
+    RetryPolicy,
+    SOURCE_APOLLO,
+    SOURCE_HUNTER,
+    SOURCE_PATTERN_GUESS,
+    TransientProviderError,
+)
+
+
+class FakeProvider:
+    def __init__(self, name: str, responses: list):
+        self.name = name
+        self._responses = list(responses)
+
+    def lookup_email(self, *, founder_name: str | None, domain: str, company: str | None = None) -> str | None:
+        if not self._responses:
+            return None
+        nxt = self._responses.pop(0)
+        if isinstance(nxt, Exception):
+            raise nxt
+        return nxt
+
+
+def test_waterfall_prefers_hunter_then_stops():
+    hunter = FakeProvider("hunter", ["ceo@acme.com"])
+    apollo = FakeProvider("apollo", ["should-not-be-used@acme.com"])
+    enricher = ContactEnricher(hunter_provider=hunter, apollo_provider=apollo)
+
+    result = enricher.enrich(founder_name="Jane Doe", domain="acme.com", company="Acme")
+
+    assert result.contact_email == "ceo@acme.com"
+    assert result.contact_email_source == SOURCE_HUNTER
+    assert result.contact_confidence == 0.95
+    assert len(result.contact_provenance) == 1
+
+
+def test_waterfall_falls_back_to_apollo():
+    hunter = FakeProvider("hunter", [None])
+    apollo = FakeProvider("apollo", ["founder@acme.com"])
+    enricher = ContactEnricher(hunter_provider=hunter, apollo_provider=apollo)
+
+    result = enricher.enrich(founder_name="Jane Doe", domain="acme.com", company="Acme")
+
+    assert result.contact_email == "founder@acme.com"
+    assert result.contact_email_source == SOURCE_APOLLO
+    assert [p["source"] for p in result.contact_provenance[:2]] == [SOURCE_HUNTER, SOURCE_APOLLO]
+
+
+def test_pattern_guess_fallback_is_deterministic():
+    hunter = FakeProvider("hunter", [None])
+    apollo = FakeProvider("apollo", [None])
+    enricher = ContactEnricher(hunter_provider=hunter, apollo_provider=apollo)
+
+    result = enricher.enrich(founder_name="Jane Doe", domain="acme.com", company="Acme")
+
+    assert result.contact_email == "jane@acme.com"
+    assert result.contact_email_source == SOURCE_PATTERN_GUESS
+    assert result.contact_confidence == 0.55
+
+
+def test_retry_backoff_and_rate_limit_handling():
+    sleeps = []
+
+    hunter = FakeProvider(
+        "hunter",
+        [
+            RateLimitError(2.5, "slow down"),
+            TransientProviderError("upstream 502"),
+            None,
+        ],
+    )
+    apollo = FakeProvider("apollo", ["apollo@acme.com"])
+    enricher = ContactEnricher(
+        hunter_provider=hunter,
+        apollo_provider=apollo,
+        retry_policy=RetryPolicy(max_attempts=3, initial_backoff_seconds=0.2, max_backoff_seconds=1.0),
+        sleep_fn=lambda seconds: sleeps.append(seconds),
+    )
+
+    result = enricher.enrich(founder_name="Jane Doe", domain="acme.com", company="Acme")
+
+    assert sleeps == [2.5, 0.2]
+    assert result.contact_email_source == SOURCE_APOLLO
+    statuses = [p["status"] for p in result.contact_provenance]
+    assert "rate_limited" in statuses
+    assert "transient_error" in statuses

--- a/tests/test_hiring_intent_signals.py
+++ b/tests/test_hiring_intent_signals.py
@@ -1,0 +1,81 @@
+import json
+import unittest
+from datetime import UTC, datetime
+from pathlib import Path
+
+from pipeline.hiring_intent_signals import build_hiring_intent_signals
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "hiring_intent_signals"
+
+
+class TestHiringIntentSignals(unittest.TestCase):
+    def _load(self, name: str):
+        return json.loads((FIXTURE_DIR / f"{name}.json").read_text(encoding="utf-8"))
+
+    def test_normalized_schema_freshness_and_dedupe(self):
+        source_records = {
+            "wellfound": self._load("wellfound"),
+            "naukri": self._load("naukri"),
+            "cutshort": self._load("cutshort"),
+            "instahyre": self._load("instahyre"),
+            "yc_jobs": self._load("yc_jobs"),
+        }
+
+        signals = build_hiring_intent_signals(
+            source_records,
+            now=datetime(2026, 3, 20, tzinfo=UTC),
+        )
+
+        # 8 raw rows -> remove 1 stale + 1 invalid + 1 duplicate = 5 unique fresh signals.
+        self.assertEqual(len(signals), 5)
+
+        required_fields = {
+            "source",
+            "company",
+            "role",
+            "location",
+            "posted_date",
+            "source_url",
+            "canonical_url",
+            "metadata",
+        }
+        for signal in signals:
+            self.assertEqual(set(signal.keys()), required_fields)
+
+            posted = datetime.fromisoformat(signal["posted_date"]).replace(tzinfo=UTC)
+            age_days = (datetime(2026, 3, 20, tzinfo=UTC) - posted).days
+            self.assertLessEqual(age_days, 60)
+
+        dedupe_keys = {
+            (s["company"].lower().strip(), s["role"].lower().strip(), s["canonical_url"]) for s in signals
+        }
+        self.assertEqual(len(dedupe_keys), len(signals))
+
+        # Canonical URL normalization strips tracking params and normalizes trailing slash.
+        acme_urls = [
+            s["canonical_url"]
+            for s in signals
+            if s["company"] == "Acme Labs" and s["role"] == "Customer Success Manager"
+        ]
+        self.assertEqual(acme_urls, ["https://wellfound.com/jobs/123"])
+
+    def test_ignores_unknown_source(self):
+        signals = build_hiring_intent_signals(
+            {
+                "unknown_source": [
+                    {
+                        "company": "X",
+                        "title": "Y",
+                        "url": "https://example.com/job",
+                        "posted_date": "2026-03-19",
+                    }
+                ]
+            },
+            now=datetime(2026, 3, 20, tzinfo=UTC),
+        )
+
+        self.assertEqual(signals, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary\nImplements #22 with deterministic founder/business email enrichment and observability.\n\n### What changed\n- Added deterministic waterfall module: pipeline/contact_enrichment.py\n  - Ordered lookup: Hunter -> Apollo -> pattern guess\n  - Provenance tracking (contact_provenance) per attempt and provider\n  - Confidence scoring by source (contact_confidence)\n  - Retry/backoff for transient failures\n  - Explicit rate-limit handling with Retry-After support\n- Extended Job schema in job_scraper.py with:\n  - ounder_email, usiness_email, contact_email, contact_email_source, contact_confidence, contact_provenance\n- Integrated enrichment into job creation flow when API keys are present\n- Added tests in 	ests/test_contact_enrichment.py\n- Updated README docs with enrichment behavior and required env vars\n\n### Tests\n- python -m pytest -q tests\n\nAlso references #16 for follow-on contact quality/operationalization context.